### PR TITLE
Not using --add-modules anymore, as we explicitily provide JAXB now

### DIFF
--- a/jaxrs-api/pom.xml
+++ b/jaxrs-api/pom.xml
@@ -182,9 +182,8 @@
                         </plugin>
                         <plugin>
                             <artifactId>maven-surefire-plugin</artifactId>
-                            <version>2.21.0</version>
                             <configuration>
-                                <argLine>--add-modules java.xml.bind --add-opens jakarta.ws.rs/jakarta.ws.rs.core=java.xml.bind</argLine>
+                                <argLine>--add-opens jakarta.ws.rs/jakarta.ws.rs.core=java.xml.bind</argLine>
                             </configuration>
                         </plugin>
                     </plugins>


### PR DESCRIPTION
`--add-modules` was formerly needed to enable JAXB on the classpath. Now that we explicitly provide a particular version of JAXB, we must not enable the JRE-provided version, as this is conflicting.

This solution to the JDK 9/10 building problem is better than simply falling back to an old version of surefire, as surefire does not imply the problem, but just suffers from our own fault.